### PR TITLE
Add workflow to publish one lib per tag to gh-pages branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+name: Publish JS library to gh-pages
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
+    - name: Checkout repo
+      uses: actions/checkout@v2
+
+    - name: Run tests
+      run: |
+        npm install -g npm@7 --registry=https://registry.npmjs.org
+        npm ci
+        npm test
+
+    - name: Publish one lib per tag to gh-pages branch
+      run: |
+        git config user.name "i-slide-bot"
+        git config user.email "<>"
+        git remote set-url --push origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+        node tools/publish-lib.js
+        git push origin gh-pages:gh-pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches:
+      - main
     tags:
       - '*'
   workflow_dispatch:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@shower/shower": "^3.2.3",
         "http-server": "^13.0.2",
         "mocha": "^9.1.1",
-        "puppeteer": "^10.2.0"
+        "puppeteer": "^10.2.0",
+        "semver": "^7.3.5"
       },
       "engines": {
         "node": ">=14.0.0",
@@ -916,6 +917,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -1368,6 +1381,21 @@
       "integrity": "sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=",
       "dev": true
     },
+    "node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
       "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
@@ -1642,6 +1670,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -2383,6 +2417,15 @@
         "is-unicode-supported": "^0.1.0"
       }
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -2708,6 +2751,15 @@
       "integrity": "sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=",
       "dev": true
     },
+    "semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
     "serialize-javascript": {
       "version": "6.0.0",
       "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
@@ -2912,6 +2964,12 @@
     "y18n": {
       "version": "5.0.8",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "test": "test"
   },
   "engines": {
-    "node": ">=14.0.0", 
-    "npm": ">=7.0.0" 
+    "node": ">=14.0.0",
+    "npm": ">=7.0.0"
   },
   "scripts": {
     "test": "mocha"
@@ -27,6 +27,7 @@
     "@shower/shower": "^3.2.3",
     "http-server": "^13.0.2",
     "mocha": "^9.1.1",
-    "puppeteer": "^10.2.0"
+    "puppeteer": "^10.2.0",
+    "semver": "^7.3.5"
   }
 }

--- a/tools/publish-lib.js
+++ b/tools/publish-lib.js
@@ -1,0 +1,59 @@
+/**
+ * Create one JS library per tag and commit the result to the gh-pages branch
+ * 
+ * node tools/publish-tags.js
+ */
+
+const util = require('util');
+const fs = require('fs');
+const execFile = util.promisify(require('child_process').execFile);
+
+async function main() {
+  console.log('Retrieve list of tags...');
+  const { stdout: tagOut } = await execFile('git', ['tag', '--sort=-v:refname']);
+  const tags = tagOut.split(/[\r\n]/).filter(tag => !!tag);
+  const lastTag = tags[0] ?? 'last commit';
+  console.log(`  ${tags.length} tags found`);
+
+  console.log('Lookup name of current branch...');
+  const { stdout: branchOut } = await execFile('git', ['branch', '--show-current']);
+  const branchName = branchOut.trim();
+  console.log(`  on branch ${branchName}`);
+
+  console.log('Switch to gh-pages branch...');
+  const { stdout: checkOut } = await execFile('git', ['checkout', 'gh-pages']);
+  console.log('  done');
+
+  console.log('Create one lib file per tag...');
+  for (const tag of tags) {
+    const { stdout: showOut } = await execFile('git', ['show', `${tag}:i-slide.js`]);
+    fs.writeFileSync(`i-slide-${tag}.js`, showOut, 'utf8');
+  }
+  console.log('  done');
+
+  console.log('Add nightly version from main branch...')
+  const { stdout: mainOut } = await execFile('git', ['show', 'main:i-slide.js']);
+  fs.writeFileSync('i-slide.js', mainOut, 'utf8');
+  console.log('  done');
+
+  console.log('Commit changes to gh-pages branch...');
+  await execFile('git', ['add', 'i-slide*.js']);
+  const { stdout: diffOut } = await execFile('git', ['diff', '--staged', '--compact-summary']);
+  if (diffOut.trim()) {
+    console.log(diffOut);
+    await execFile('git', ['commit', '-m', `Update published libs for ${lastTag}`]);
+    console.log('  done');
+  }
+  else {
+    console.log('  nothing to commit');
+  }
+
+  console.log('Switch back to initial branch...');
+  await execFile('git', ['checkout', branchName]);
+  console.log('  done');
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tools/publish-lib.js
+++ b/tools/publish-lib.js
@@ -6,14 +6,41 @@
 
 const util = require('util');
 const fs = require('fs');
+const semver = require('semver');
 const execFile = util.promisify(require('child_process').execFile);
+
+const lib = 'i-slide';
+
+async function writeLib(ref, filename) {
+  filename = filename || `${lib}-${ref}`;
+  const { stdout: showOut } = await execFile('git', ['show', `${ref}:${lib}.js`]);
+  fs.writeFileSync(`${filename}.js`, showOut, 'utf8');
+}
 
 async function main() {
   console.log('Retrieve list of tags...');
   const { stdout: tagOut } = await execFile('git', ['tag', '--sort=-v:refname']);
-  const tags = tagOut.split(/[\r\n]/).filter(tag => !!tag);
-  const lastTag = tags[0] ?? 'last commit';
+  const tags = tagOut.split(/[\r\n]/)
+    .filter(tag => !!tag)
+    .filter(tag => semver.valid(semver.clean(tag)));
+  const lastTag = tags[0] ?? 'main';
   console.log(`  ${tags.length} tags found`);
+
+  console.log('Find major versions...');
+  const majorVersions = tags
+    .map(tag => Object.assign({
+      major: semver.major(semver.clean(tag)),
+      tag
+    }))
+    .filter((item, pos, arr) =>
+      item.major !== null &&
+      arr.find(i => i.major === item.major) === item);
+  if (majorVersions.length) {
+    majorVersions.forEach(m => console.log(`  ${m.major} => ${m.tag}`));
+  }
+  else {
+    console.log('  no major version found');
+  }
 
   console.log('Lookup name of current branch...');
   const { stdout: branchOut } = await execFile('git', ['branch', '--show-current']);
@@ -26,14 +53,29 @@ async function main() {
 
   console.log('Create one lib file per tag...');
   for (const tag of tags) {
-    const { stdout: showOut } = await execFile('git', ['show', `${tag}:i-slide.js`]);
-    fs.writeFileSync(`i-slide-${tag}.js`, showOut, 'utf8');
+    await writeLib(tag, `${lib}-${semver.clean(tag)}`);
   }
   console.log('  done');
 
+  console.log('Create one lib file per major version...');
+  for (const version of majorVersions) {
+    await writeLib(version.tag, `${lib}-${version.major}`);
+  }
+  console.log('  done');
+
+  console.log('Add latest release...')
+  await writeLib(lastTag, lib);
+  console.log('  done');
+
   console.log('Add nightly version from main branch...')
-  const { stdout: mainOut } = await execFile('git', ['show', 'main:i-slide.js']);
-  fs.writeFileSync('i-slide.js', mainOut, 'utf8');
+  await writeLib('main', `${lib}-nightly`);
+  console.log('  done');
+
+  console.log('Update README and LICENSE if needed...');
+  for (const file of ['README.md', 'LICENSE']) {
+    const { stdout: fileOut } = await execFile('git', ['show', `${lastTag}:${file}`]);
+    fs.writeFileSync(file, fileOut, 'utf8');
+  }
   console.log('  done');
 
   console.log('Commit changes to gh-pages branch...');


### PR DESCRIPTION
The workflow runs whenever a tag gets added to the repository. It updates the gh-pages branch as needed with new versions of the JS library:
- one file per version, e.g. i-slide-v1.0.0.js
- the nightly version, named i-slide.js