### PR TITLE
Restrict test workflow to PR

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -1,9 +1,8 @@
 on:
-  push:
-    branches: main
   pull_request:
     branches: main
-name: test
+
+name: Test PR
 
 jobs:
   test:


### PR DESCRIPTION
Tests already get run when a push is made against the main branch.