### PR TITLE
Prevent overflows and flag as block element for PDF as well

### DIFF
--- a/i-slide.js
+++ b/i-slide.js
@@ -375,7 +375,7 @@ class ISlide extends HTMLElement {
 
       }
     } catch (err) {
-      console.error(err.toString());
+      console.error(err.toString(), err);
       this.shadowRoot.innerHTML = "";
       const doc = document.createElement('div');
       doc.innerHTML = this.innerHTML.trim() || `<a href="${this.src}">${this.src}</a>`;

--- a/test/i-slide.js
+++ b/test/i-slide.js
@@ -20,197 +20,233 @@ const rootUrl = `http://localhost:${port}`;
 const baseUrl = `${rootUrl}/test/resources/`;
 const debug = !!process.env.DEBUG;
 
-async function evalComponent(page, shadowTreePaths, slideNumber = 0) {
-  return page.evaluate(async (shadowTreePaths, slideNumber) => {
-    function extractInfo(el) {
-      const res = {};
-      for (let path of shadowTreePaths) {
-        if (path === ".width") {
-          res[".width"] = Math.floor(el.shadowRoot.querySelector("body").getBoundingClientRect().width);
-        } else {
-          const [child, attr] = path.split(".");
-          res[path] = attr ? el.shadowRoot.querySelector(child)?.getAttribute(attr) : !!el.shadowRoot.querySelector(child);
-        }
-      }
-      return res;
-    }
-    const el = document.querySelectorAll("i-slide")[slideNumber];
-    if (!el) {
-      return {error: "cannot find Web Component"};
-    }
-    if (el.loaded) return extractInfo(el);
-    let resolve;
-    const p = new Promise((res, rej) => {
-      resolve = res;
-    });
-    el.addEventListener("load", () => {
-      resolve(extractInfo(el));
-    });
-    return p;
-  }, shadowTreePaths, slideNumber);
-}
-
 const islideLoader = `
 <!DOCTYPE html>
 <html>
   <script src="${rootUrl}/i-slide.js" type="module" defer></script>
   <body>`;
 
-const tests = [
-  {title: "loads a single shower slide",
-   slides: [ { url: "shower.html#1" } ],
-   expects: [ // for each i-slide component in the page
-     [ // a series of expectations
-       {
-         path: "img.src", // the Shadow DOM "path" being evaluated
-         result: rootUrl + "/node_modules/@shower/shower/pictures/cover.jpg"
-       },
-       {
-         path: ".width", // FIXME: not an actual DOM path
-         result: 300
-       }
-     ]
-   ]
+
+/**
+ * List of declarative tests, defined as an object whose keys are test titles,
+ * and whose values describe a slide set. The slide set needs to be an array of
+ * slide objects. The array level may be omitted if the slideset contains only
+ * one slide.
+ *
+ * A slide object must contain the following properties:
+ * - "slide": either a string interpreted as the slide URL or an object with a
+ *   "url" property, and possibly a "width" property and/or "innerHTML" property
+ * - "expects": A list of expectations (an array), or a single expectation (an
+ *   object).
+ *
+ * An expectation is an object with:
+ * - a "path" property that is a CSS selector to the element to evaluate,
+ * starting from the shadow root of the <i-slide> element, with the following
+ * extensions to CSS selectors:
+ *   1. if the string ends with "@name", the value of the attribute "name" on
+ *   the matched element is evaluated. For instance: "div>a@href" evaluates the
+ *   "href" attribute of the "div>a" element.
+ *   2. the string ".width" evaluates to the width of the "body" element of the
+ *   shadow root (TODO: find a better way to express this)
+ * - a mandatory "result" property that gives the expected result of the
+ * evaluation. For attributes, this is the expected value. For elements, this
+ * needs to be a boolean (true when element is expected, false otherwise). The
+ * "eval" property can be used to change this meaning.
+ * - an "eval" property that can be used to provide a specific evaluation
+ * function. The evaluation function gets evaluated in the context of the loaded
+ * page. It must return a serializable object. The "eval" function gets called
+ * without argument, but note "window.slideEl" is set to the current <i-slide>
+ * element when that function is called. The "path" property has no meaning when
+ * "eval" is set.
+ */
+const tests = {
+  "loads a single shower slide": {
+    slide: "shower.html#1",
+    expects: [
+      { path: "img@src", result: rootUrl + "/node_modules/@shower/shower/pictures/cover.jpg" },
+      { path: ".width", result: 300 }
+    ]
   },
-  {title:"loads multiple shower slides",
-   slides: [ { url: "shower.html#1" }, { url: "shower.html#2", width: 500 }, { url: "shower.html#4" }, { url: "shower.html#25" } ],
-   expects: [
-     [
-       {
-         path: "img.src",
-         result: rootUrl + "/node_modules/@shower/shower/pictures/cover.jpg"
-       },
-       {
-         path: ".width",
-         result: 300
-       }
-     ],
-     [
-       {
-         path: "ol",
-         result: true
-       },
-       {
-         path: ".width",
-         result: 500
-       }
-     ],
-     [
-       {
-         path: "p",
-         result: true
-       },
-       {
-         path: ".width",
-         result: 300
-       }
-     ],
-     [
-       {
-         path: "a.href",
-         result: baseUrl + "shower.html#25"
-       }
-     ]
-   ]
+
+  "loads multiple shower slides": [
+    {
+      slide: "shower.html#1",
+      expects: [
+        { path: "img@src", result: rootUrl + "/node_modules/@shower/shower/pictures/cover.jpg" },
+        { path: ".width", result: 300 }
+      ]
+    },
+    {
+      slide: { url: "shower.html#2", width: 500 },
+      expects: [
+        { path: "ol", result: true },
+        { path: ".width", result: 500 }
+      ]
+    },
+    {
+      slide: "shower.html#4",
+      expects: [
+        { path: "p", result: true },
+        { path: ".width", result: 300 }
+      ]
+    },
+    {
+      slide: "shower.html#25",
+      expects: [
+        { path: "a@href", result: baseUrl + "shower.html#25" }
+      ]
+    }
+  ],
+
+  "loads a single b6+ slide": {
+    slide: "https://www.w3.org/Talks/Tools/b6plus/#3",
+    expects: [
+      { path: "a@href", result: "https://www.w3.org/Talks/Tools/b6plus/simple.css" },
+      { path: ".width", result: 300 }
+    ]
   },
-  {title: "loads a single b6+ slide",
-   slides: [ { url: "https://www.w3.org/Talks/Tools/b6plus/#3" } ],
-   expects: [
-     [
-       {
-         path: "a.href",
-          result: "https://www.w3.org/Talks/Tools/b6plus/simple.css"
-       },
-       {
-         path: ".width",
-          result: 300
-       }
-     ]
-   ]
+
+  "loads a single PDF slide": {
+    slide: "slides.pdf#page=1",
+    expects: [
+      { path: "canvas@width", result: 300 },
+      { path: "a@href", result: "https://github.com/tidoust/i-slide/" }
+    ]
   },
-  {title: "loads a single PDF slide",
-   slides: [ { url: "slides.pdf#page=1"} ],
-   expects: [
-     [
-       {
-         path: "canvas.width",
-         result: 300
-       },
-       {
-         path: "a.href",
-         result: "https://github.com/tidoust/i-slide/"
-       }
-     ]
-   ]
+
+  "loads multiple PDF slides": [
+    {
+      slide: "slides.pdf#page=1",
+      expects: [
+        { path: "canvas@width", result: 300 },
+        { path: "a@href", result: "https://github.com/tidoust/i-slide/" }
+      ]
+    },
+    {
+      slide: "slides.pdf#2",
+      expects: { path: "canvas@width", result: 300 }
+    },
+    {
+      slide: "slides.pdf#foo",
+      expects: { path: "a@href", result: baseUrl + "slides.pdf#foo" }
+    },
+    {
+      slide: "slides.pdf#45",
+      expects: { path: "a@href", result: baseUrl + "slides.pdf#45" }
+    }
+  ],
+
+  "fallbacks to a link on CORS error": {
+    slide: "about:blank#1",
+    expects: { path: "a@href", result: "about:blank#1" }
   },
-  {title: "loads multiple PDF slides",
-   slides: [ { url: "slides.pdf#page=1"}, { url: "slides.pdf#2"}, { url: "slides.pdf#foo"}, { url: "slides.pdf#45"} ],
-   expects: [
-     [
-       {
-         path: "canvas.width",
-         result: 300
-       },
-       {
-         path: "a.href",
-         result: "https://github.com/tidoust/i-slide/"
-       }
-     ],
-     [
-       {
-         path: "canvas.width",
-         result: 300
-       }
-     ],
-     [
-       {
-         path: "a.href",
-         result: baseUrl + "slides.pdf#foo"
-       }
-     ],
-     [
-       {
-         path: "a.href",
-         result: baseUrl + "slides.pdf#45"
-       }
-     ]
-   ]
+
+  "fallbacks to a link on fetch errors": [
+    {
+      slide: "about:blank#1",
+      expects: { path: "a@href", result: "about:blank#1" }
+    },
+    {
+      slide: { url: "about:blank#1", innerHTML: "<span>Fallback</span>"},
+      expects: { path: "span", result: true }
+    },
+    {
+      slide: "404.html",
+      expects: { path: "a@href", result: baseUrl + "404.html" }
+    }
+  ],
+
+  "renders as a block element for HTML slides": {
+    slide: "shower.html#1",
+    expects: {
+      eval: el => window.getComputedStyle(window.slideEl).display,
+      result: "block"
+    }
   },
-  {title: "fallbacks to a link on CORS error",
-   slides: [ {url: "about:blank#1"} ],
-   expects: [
-     [
-       {
-         path: "a.href",
-         result: "about:blank#1"
-       }
-     ]
-   ]
+
+  "renders as a block element for PDF slides": {
+    slide: "slides.pdf#1",
+    expects: {
+      eval: el => window.getComputedStyle(window.slideEl).display,
+      result: "block"
+    }
   },
-  {title: "fallback to a link on fetch errors",
-   slides: [ {url: "about:blank#1"}, { url: "about:blank#1", innerHTML: "<span>Fallback</span>"}, {url: "404.html" } ],
-   expects: [
-     [
-       {
-         path: "a.href",
-         result: "about:blank#1"
-       }
-     ],
-     [
-       {
-         path: "span",
-         result: true
-       }
-     ],
-     [
-       {
-         path: "a.href",
-         result: baseUrl + "404.html"
-       }
-     ]
-   ]
+
+  "sets the styles of the root element properly for HTML slides": {
+    slide: "shower.html#1",
+    expects: {
+      eval: el => {
+        const rootEl = window.slideEl.shadowRoot.querySelector("html");
+        const styles = window.getComputedStyle(rootEl);
+        return `${styles.position}|${styles.overflow}|${styles.height}`;
+      },
+      result: "relative|hidden|168.75px" // 300 = 16/9 * 168.75
+    }
+  },
+
+  "sets the styles of the root element properly for PDF slides": {
+    slide: "slides.pdf#1",
+    expects: {
+      eval: el => {
+        const rootEl = window.slideEl.shadowRoot.querySelector("div");
+        const styles = window.getComputedStyle(rootEl);
+        return `${styles.position}|${styles.overflow}`;
+      },
+      result: "relative|hidden"
+    }
   }
-];
+};
+
+
+async function evalComponent(page, expectations, slideNumber = 0) {
+  try {
+    // Set current <i-slide> el and wait for page to be fully loaded
+    await page.evaluate(async (slideNumber) => {
+      const el = document.querySelectorAll("i-slide")[slideNumber];
+      if (!el) {
+        throw new Error("cannot find Web Component");
+      }
+      window.slideEl = el;
+      if (el.loaded) {
+        return;
+      }
+
+      let resolve;
+      const p = new Promise((res, rej) => {
+        resolve = res;
+      });
+      el.addEventListener("load", () => {
+        resolve();
+      });
+      return p;
+    }, slideNumber);
+
+    // Evaluate expectations one by one (needed to be able to run custom
+    // evaluation functions)
+    return Promise.all(expectations.map(async (expect, k) => {
+      if (expect.eval) {
+        return page.evaluate(expect.eval);
+      }
+      else {
+        return page.evaluate(async (path) => {
+          const el = window.slideEl;
+          if (path === ".width") {
+            return Math.floor(el.shadowRoot.querySelector("body").getBoundingClientRect().width);
+          }
+          else {
+            const [selector, attr] = (path || "").split("@");
+            const child = selector ? el.shadowRoot.querySelector(selector) : el;
+            return attr ? child?.getAttribute(attr) : !!child;
+          }
+        }, expect.path);
+      }
+    }));
+  }
+  catch (err) {
+    return {error: err.toString()};
+  }
+}
+
 
 describe("Test loading slides", function() {
   this.slow(20000);
@@ -220,30 +256,40 @@ describe("Test loading slides", function() {
     browser = await puppeteer.launch({ headless: !debug });
   });
 
-  tests.forEach(t => {
-    it(t.title, async() => {
+  for (let [title, slideset] of Object.entries(tests)) {
+    //if (title !== "renders as a block element in HTML slides") continue;
+    slideset = Array.isArray(slideset) ? slideset : [slideset];
+
+    it(title, async () => {
       const page = await browser.newPage();
       await page.setRequestInterception(true);
       const injectContent = async req => {
-        const html = t.slides.map(s => `<i-slide src="${new URL(s.url, baseUrl).href}" ${s.width ? `width=${s.width}`: ""}}>${s.innerHTML ?? ""}</i-slide>`).join("\n");
+        const html = slideset.map(s => {
+          const slide = (typeof s.slide === "string") ? { url: s.slide } : s.slide;
+          return `<i-slide
+            src="${new URL(slide.url, baseUrl).href}"
+            ${slide.width ? `width=${slide.width}`: ""}}>
+              ${slide.innerHTML ?? ""}
+            </i-slide>`;
+        }).join("\n");
         req.respond({
           body: islideLoader + html
         });
         await page.setRequestInterception(false);
       };
       page.once('request', injectContent);
-      page.on("console", msg => console.log(msg));
+      page.on("console", msg => console.log(msg.text()));
       await page.goto(rootUrl);
-      for (let i = 0 ; i < t.expects.length; i++) {
-        const paths = t.expects[i].map(e => e.path);
-        const res = await evalComponent(page, paths, i);
-        for (let e of t.expects[i]) {
-          assert.equal(res[e.path], e.result);
+      for (let i = 0; i < slideset.length; i++) {
+        const expects = Array.isArray(slideset[i].expects) ?
+          slideset[i].expects : [slideset[i].expects];
+        const res = await evalComponent(page, expects, i);
+        for (let k = 0; k < expects.length; k++) {
+          assert.equal(res[k], expects[k].result);
         }
       }
     });
-  });
-
+  }
 
   after(async () => {
     if (!debug) {

--- a/test/i-slide.js
+++ b/test/i-slide.js
@@ -180,7 +180,7 @@ const tests = {
         const styles = window.getComputedStyle(rootEl);
         return `${styles.position}|${styles.overflow}|${styles.height}`;
       },
-      result: "relative|hidden|168.75px" // 300 = 16/9 * 168.75
+      result: `relative|hidden|${300/(16/9)}px`
     }
   },
 


### PR DESCRIPTION
This adds back the `overflow: hidden` directive, coupled with a `position: relative` directive to make sure that absolutely positioned elements respect the overflow.

The `:host` styles were not set in the PDF case, which meant that the custom element was rendered as an inline element. This did not have any consequence whatsoever, but the custom element should be a block element regardless of the type of slides that get displayed.

From a testing perspective, I'm not really sure how to access these properties. There are set on the `:host`, which is neither the element itself, nor the shadow root, so I don't see any immediate way to `querySelector` the right "element" to read the values I'm interested in...