### PR TITLE
Add height attribute and resize content automatically

### DIFF
--- a/i-slide.js
+++ b/i-slide.js
@@ -657,6 +657,9 @@ class ISlide extends HTMLElement {
       case 'width':
         this.width = newValue;
         break;
+      case 'height':
+        this.height = newValue;
+        break;
     }
   }
 

--- a/test/i-slide.js
+++ b/test/i-slide.js
@@ -23,6 +23,7 @@ const debug = !!process.env.DEBUG;
 const islideLoader = `
 <!DOCTYPE html>
 <html>
+  ${debug ? '<script type="text/javascript">const DEBUG = true;</script>' : ''}
   <script src="${rootUrl}/i-slide.js" type="module" defer></script>
   <body>`;
 

--- a/test/i-slide.js
+++ b/test/i-slide.js
@@ -19,6 +19,7 @@ const port = process.env.PORT ?? 8081;
 const rootUrl = `http://localhost:${port}`;
 const baseUrl = `${rootUrl}/test/resources/`;
 const debug = !!process.env.DEBUG;
+const testTitle = process.env.ISLIDETEST;
 
 const islideLoader = `
 <!DOCTYPE html>
@@ -173,6 +174,14 @@ const tests = {
     }
   },
 
+  "renders as a 300px wide element by default": {
+    slide: "shower.html#1",
+    expects: {
+      eval: _ => window.getComputedStyle(window.slideEl).width,
+      result: '300px'
+    }
+  },
+
   "sets the styles of the root element properly for HTML slides": {
     slide: "shower.html#1",
     expects: {
@@ -229,12 +238,13 @@ const tests = {
       eval: async _ => {
         const el = window.slideEl;
         el.setAttribute("width", 400);
+        el.setAttribute("height", 200);
         el.setAttribute("type", "text/html");
         el.setAttribute("src", "test/resources/shower.html#2");
-        return `width:${el.width} type:${el.type} src:${el.src}`;
+        return `width:${el.width} height:${el.height} type:${el.type} src:${el.src}`;
       },
       // NB: the "src" property returns the absolute URL (as for <img> elements)
-      result: `width:400 type:text/html src:${baseUrl}shower.html#2`
+      result: `width:400 height:200 type:text/html src:${baseUrl}shower.html#2`
     }
   },
 
@@ -244,11 +254,222 @@ const tests = {
       eval: async _ => {
         const el = window.slideEl;
         el.width = 400;
+        el.height = 200;
         el.type = "text/html";
         el.src = "test/resources/shower.html#2";
-        return `width:${el.getAttribute('width')} type:${el.getAttribute('type')} src:${el.getAttribute('src')}`;
+        return `width:${el.getAttribute('width')} height:${el.getAttribute('height')} type:${el.getAttribute('type')} src:${el.getAttribute('src')}`;
       },
-      result: `width:400 type:text/html src:test/resources/shower.html#2`
+      result: `width:400 height:200 type:text/html src:test/resources/shower.html#2`
+    }
+  },
+
+  "renders as a box with the requested dimensions (HTML slide)": {
+    slide: { url: "shower.html#1", width: 400, height: 400 },
+    expects: {
+      eval: async _ => {
+        const styles = window.getComputedStyle(window.slideEl);
+        return `width:${styles.width} height:${styles.height}`;
+      },
+      result: "width:400px height:400px"
+    }
+  },
+
+  "renders as a box with the requested dimensions (PDF slide)": {
+    slide: { url: "slides.pdf#1", width: 400, height: 400 },
+    expects: {
+      eval: async _ => {
+        const styles = window.getComputedStyle(window.slideEl);
+        return `width:${styles.width} height:${styles.height}`;
+      },
+      result: "width:400px height:400px"
+    }
+  },
+
+  "scales content to fit the available width (HTML slide)": {
+    slide: { url: "shower.html#1", width: 144, height: 144 },
+    expects: {
+      eval: async _ => {
+        const rootEl = window.slideEl.shadowRoot.querySelector("html");
+        const styles = window.getComputedStyle(rootEl);
+        return `width:${styles.width} height:${styles.height}`;
+      },
+      result: `width:144px height:${144/(16/9)}px`
+    }
+  },
+
+  "scales content to fit the available height (HTML slide)": {
+    slide: { url: "shower.html#1", width: 600, height: 144 },
+    expects: {
+      eval: async _ => {
+        const rootEl = window.slideEl.shadowRoot.querySelector("html");
+        const styles = window.getComputedStyle(rootEl);
+        return `width:${styles.width} height:${styles.height}`;
+      },
+      result: `width:${144*(16/9)}px height:144px`
+    }
+  },
+
+  "scales content to fit the available width (PDF slide)": {
+    slide: { url: "slides.pdf#1", width: 144, height: 144 },
+    expects: {
+      eval: async _ => {
+        const rootEl = window.slideEl.shadowRoot.querySelector("canvas");
+        const styles = window.getComputedStyle(rootEl);
+        return `width:${styles.width} height:${styles.height}`;
+      },
+      result: `width:144px height:${144/(16/9)}px`
+    }
+  },
+
+  "scales content to fit the available height (PDF slide)": {
+    slide: { url: "slides.pdf#1", width: 600, height: 144 },
+    expects: {
+      eval: async _ => {
+        const rootEl = window.slideEl.shadowRoot.querySelector("canvas");
+        const styles = window.getComputedStyle(rootEl);
+        return `width:${styles.width} height:${styles.height}`;
+      },
+      result: `width:${144*(16/9)}px height:144px`
+    }
+  },
+
+  "scales content to fit the available width when CSS sets the box dimensions": {
+    slide: { url: "shower.html#1", css: "i-slide { width: 144px }" },
+    expects: {
+      eval: async _ => {
+        const rootEl = window.slideEl.shadowRoot.querySelector("html");
+        const styles = window.getComputedStyle(rootEl);
+        return `width:${styles.width} height:${styles.height}`;
+      },
+      result: `width:144px height:${144/(16/9)}px`
+    }
+  },
+
+  "scales content to fit the available height when CSS sets the box dimensions": {
+    slide: { url: "shower.html#1", css: "i-slide { height: 144px }" },
+    expects: {
+      eval: async _ => {
+        const rootEl = window.slideEl.shadowRoot.querySelector("html");
+        const styles = window.getComputedStyle(rootEl);
+        return `width:${styles.width} height:${styles.height}`;
+      },
+      result: `width:${144*(16/9)}px height:144px`
+    }
+  },
+
+  "scales content when box gets sized down (HTML slide)": {
+    slide: { url: "shower.html#1" },
+    expects: {
+      eval: async _ => {
+        window.slideEl.style.width = "144px";
+        let resolve;
+        const promise = new Promise(res => resolve = res);
+
+        // Need to give code a bit of time to process the resize
+        window.setTimeout(_ => {
+          const rootEl = window.slideEl.shadowRoot.querySelector("html");
+          const styles = window.getComputedStyle(rootEl);
+          resolve(`width:${styles.width} height:${styles.height}`);
+        }, 100);
+        return promise;
+      },
+      result: `width:144px height:${144/(16/9)}px`
+    }
+  },
+
+  "scales content when box gets sized down (PDF slide)": {
+    slide: { url: "slides.pdf#1" },
+    expects: {
+      eval: async _ => {
+        window.slideEl.style.height = "144px";
+        let resolve;
+        const promise = new Promise(res => resolve = res);
+
+        // Need to give code a bit of time to process the resize
+        window.setTimeout(_ => {
+          const rootEl = window.slideEl.shadowRoot.querySelector("canvas");
+          const styles = window.getComputedStyle(rootEl);
+          resolve(`width:${styles.width} height:${styles.height}`);
+        }, 100);
+        return promise;
+      },
+      result: `width:${144*(16/9)}px height:144px`
+    }
+  },
+
+  "renders new slide correctly when slide changes (HTML to HTML)": {
+    slide: { url: "shower.html#1", width: 144 },
+    expects: {
+      eval: async _ => {
+        let resolve;
+        const promise = new Promise(res => resolve = res);
+
+        window.slideEl.addEventListener("load", _ => {
+          const rootEl = window.slideEl.shadowRoot.querySelector("html");
+          const styles = window.getComputedStyle(rootEl);
+          resolve(`width:${styles.width} height:${styles.height}`);
+        });
+        window.slideEl.src = "test/resources/shower.html#2";
+        return promise;
+      },
+      result: `width:144px height:${144/(16/9)}px`
+    }
+  },
+
+  "renders new slide correctly when slide changes (PDF to PDF)": {
+    slide: { url: "slides.pdf#1", width: 144 },
+    expects: {
+      eval: async _ => {
+        let resolve;
+        const promise = new Promise(res => resolve = res);
+
+        window.slideEl.addEventListener("load", _ => {
+          const rootEl = window.slideEl.shadowRoot.querySelector("canvas");
+          const styles = window.getComputedStyle(rootEl);
+          resolve(`width:${styles.width} height:${styles.height}`);
+        });
+        window.slideEl.src = "test/resources/slides.pdf#2";
+        return promise;
+      },
+      result: `width:144px height:${144/(16/9)}px`
+    }
+  },
+
+  "renders new slide correctly when slide changes (HTML to PDF)": {
+    slide: { url: "shower.html#1", height: 144 },
+    expects: {
+      eval: async _ => {
+        let resolve;
+        const promise = new Promise(res => resolve = res);
+
+        window.slideEl.addEventListener("load", _ => {
+          const rootEl = window.slideEl.shadowRoot.querySelector("canvas");
+          const styles = window.getComputedStyle(rootEl);
+          resolve(`width:${styles.width} height:${styles.height}`);
+        });
+        window.slideEl.src = "test/resources/slides.pdf#1";
+        return promise;
+      },
+      result: `width:${144*(16/9)}px height:144px`
+    }
+  },
+
+  "renders new slide correctly when slide changes (PDF to HTML)": {
+    slide: { url: "slides.pdf#1", height: 144 },
+    expects: {
+      eval: async _ => {
+        let resolve;
+        const promise = new Promise(res => resolve = res);
+
+        window.slideEl.addEventListener("load", _ => {
+          const rootEl = window.slideEl.shadowRoot.querySelector("html");
+          const styles = window.getComputedStyle(rootEl);
+          resolve(`width:${styles.width} height:${styles.height}`);
+        });
+        window.slideEl.src = "test/resources/shower.html#1";
+        return promise;
+      },
+      result: `width:${144*(16/9)}px height:144px`
     }
   }
 };
@@ -324,6 +545,7 @@ describe("Test loading slides", function() {
   });
 
   for (let [title, slideset] of Object.entries(tests)) {
+    if (testTitle && !title.includes(testTitle)) continue;
     slideset = Array.isArray(slideset) ? slideset : [slideset];
 
     it(title, async () => {
@@ -332,9 +554,11 @@ describe("Test loading slides", function() {
       const injectContent = async req => {
         const html = slideset.map(s => {
           const slide = (typeof s.slide === "string") ? { url: s.slide } : s.slide;
-          return `<i-slide
-            src="${new URL(slide.url, baseUrl).href}"
-            ${slide.width ? `width=${slide.width}`: ""}>
+          return `
+            ${slide.css ? "<style>" + slide.css + "</style>" : ""}
+            <i-slide src="${new URL(slide.url, baseUrl).href}"
+                ${slide.width ? `width=${slide.width}`: ""}
+                ${slide.height ? `height=${slide.height}`: ""}>
               ${slide.innerHTML ?? ""}
             </i-slide>`;
         }).join("\n");
@@ -358,17 +582,19 @@ describe("Test loading slides", function() {
     });
   }
 
-  it('loads the slides on the demo page as expected', async () => {
-    const page = await browser.newPage();
-    await page.goto(baseUrl + 'demo.html');
-    for (let i = 0; i < demoTestExpectations; i++) {
-      const expects = demoTestExpectations[i];
-      const res = await evalComponent(page, expects, i);
-      for (let k = 0; k < expects.length; k++) {
-        assert.equal(res[k], expects[k].result);
+  if (!testTitle) {
+    it('loads the slides on the demo page as expected', async () => {
+      const page = await browser.newPage();
+      await page.goto(baseUrl + 'demo.html');
+      for (let i = 0; i < demoTestExpectations; i++) {
+        const expects = demoTestExpectations[i];
+        const res = await evalComponent(page, expects, i);
+        for (let k = 0; k < expects.length; k++) {
+          assert.equal(res[k], expects[k].result);
+        }
       }
-    }
-  });
+    });
+  }
 
   after(async () => {
     if (!debug) {


### PR DESCRIPTION
The `height` attribute completes the "width" attribute and allows authors to fully impose the size the `<i-slide>` element in the HTML. When the aspect ratio of the element is different from the intrinsic aspect ratio of the slide, the slide is rendered as though it was styled with:

```css
  object-fit: contain;
  object-position: top left;
```

These properties should be properly supported and default would also need to change to `fill` and `50% 50%` as defined in CSS. That is a TODO...

The contents of the `<i-slide>` element are now also automatically scaled up/down when additional CSS dimension constraints are imposed on the element. This gets done by using a `ResizeObserver`.

The scaling logic was moved out of `#render()`. A number of private properties had to be added to track last known info about the slide that is rendered, e.g. to keep a pointer to the PDF page and more importantly to keep track of the last applied scale and target dimensions so as not to re-scale content when that is not needed. These properties could perhaps be consolidated in a `this.#slideInfo` object (not done here).

The render logic may not need to remain serialized but debugging renders and resizes is already hard enough when things are serialized...

The code now also includes a `log` function to log a few function calls to the console. Function is a no-op by default and enabled by setting a global `DEBUG` variable. That variable gets set when tests are run in debug mode.

Tests completed to cover most common scenarios (although many more tests could be written...). Tests include a few tests on dynamically changing the URL of the slide because it's easy to forget to reset something when the source of the slide changes...

The test framework was updated to check the presence of an `ISLIDETEST` environment variable. When set, the test framework only runs tests whose title contains the value of the `ISLIDETEST` variable. This makes it easier to run a single test (or a restricted set of tests) while developing the test suite, as well as to run a single test in DEBUG mode.

Fixes #19