### PR TITLE
Remove the `defer` attribute on module scripts

### DIFF
--- a/test/i-slide.js
+++ b/test/i-slide.js
@@ -25,7 +25,7 @@ const islideLoader = `
 <!DOCTYPE html>
 <html>
   ${debug ? '<script type="text/javascript">const DEBUG = true;</script>' : ''}
-  <script src="${rootUrl}/i-slide.js" type="module" defer></script>
+  <script src="${rootUrl}/i-slide.js" type="module"></script>
   <body>`;
 
 

--- a/test/resources/demo.html
+++ b/test/resources/demo.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset=utf-8>
     <title>Demo of the &lt;i-slide&gt; Web component</title>
-    <script src="https://w3c.github.io/i-slide/i-slide-1.js" type=module defer></script>
+    <script src="https://w3c.github.io/i-slide/i-slide-1.js" type=module></script>
   </head>
   <body>
     <h1>Demo of the &lt;i-slide&gt; Web component</h1>


### PR DESCRIPTION
https://validator.w3.org/nu/?showsource=yes&doc=https%3A%2F%2Fw3c.github.io%2Fi-slide%2Fdemo.html:

> **Error**: A `script` element with a `defer` attribute must not have a `type` attribute with the value `module`.