### PR TITLE
i-slide as a customized built-in element

### DIFF
--- a/i-slide.js
+++ b/i-slide.js
@@ -72,7 +72,7 @@ const PDFScriptsLoaded = new Promise((resolve, reject) => {
 /**
  * The i-slide Web component
  */
-class ISlide extends HTMLElement {
+class ISlide extends HTMLSpanElement {
   /**
    * A fetch-and-render cycle has been scheduled to run during next tick
    */
@@ -284,6 +284,11 @@ class ISlide extends HTMLElement {
     super();
     this.loaded = false;
     this.attachShadow({ mode: 'open' });
+
+    // Find the element inside this SPAN that points to the slide.
+    // TODO: Add a watch for future changes to the href attribute.
+    let a = this.querySelector("[href]");
+    if (a) this.src = a.href;
 
     // Scale content when element gets resized, unless a render is already
     // planned, or unless a fetch is needed (in other words unless no
@@ -844,6 +849,6 @@ class ISlide extends HTMLElement {
 }
 
 // Register the custom element
-customElements.define('i-slide', ISlide);
+customElements.define('i-slide', ISlide, {extends: "span"});
 
 export default ISlide;

--- a/test/i-slide.js
+++ b/test/i-slide.js
@@ -342,7 +342,7 @@ const tests = {
   },
 
   "scales content to fit the available width when CSS sets the box dimensions": {
-    slide: { url: "shower.html#1", css: "i-slide { width: 144px }" },
+    slide: { url: "shower.html#1", css: "[is=i-slide] { width: 144px }" },
     expects: {
       eval: async _ => {
         const rootEl = window.slideEl.shadowRoot.querySelector("html");
@@ -354,7 +354,7 @@ const tests = {
   },
 
   "scales content to fit the available height when CSS sets the box dimensions": {
-    slide: { url: "shower.html#1", css: "i-slide { height: 144px }" },
+    slide: { url: "shower.html#1", css: "[is=i-slide] { height: 144px }" },
     expects: {
       eval: async _ => {
         const rootEl = window.slideEl.shadowRoot.querySelector("html");
@@ -498,7 +498,7 @@ async function evalComponent(page, expectations, slideNumber = 0) {
   try {
     // Set current <i-slide> el and wait for page to be fully loaded
     await page.evaluate(async (slideNumber) => {
-      const el = document.querySelectorAll("i-slide")[slideNumber];
+      const el = document.querySelectorAll("span[is=i-slide]")[slideNumber];
       if (!el) {
         throw new Error("cannot find Web Component");
       }
@@ -564,11 +564,11 @@ describe("Test loading slides", function() {
           const slide = (typeof s.slide === "string") ? { url: s.slide } : s.slide;
           return `
             ${slide.css ? "<style>" + slide.css + "</style>" : ""}
-            <i-slide src="${new URL(slide.url, baseUrl).href}"
+            <span is=i-slide><a href="${new URL(slide.url, baseUrl).href}"
                 ${slide.width ? `width=${slide.width}`: ""}
                 ${slide.height ? `height=${slide.height}`: ""}>
               ${slide.innerHTML ?? ""}
-            </i-slide>`;
+            test</a></span>`;
         }).join("\n");
         req.respond({
           body: islideLoader + html

--- a/test/resources/demo.html
+++ b/test/resources/demo.html
@@ -27,10 +27,5 @@
     <p>allows to embed the fifth slide of the referenced slideset:</p>
     <p><span is=i-slide width="500"><a href='https://www.w3.org/2020/Talks/mlws/ba-media.pdf#page=5'>PDF slide 5</a></span></p>
 
-    <p>It is also possble to use <code>&lt;i-slide&gt;</code> as a tag. But note that this means there will be no link to the slide if JavaScript is turned off or it the page is used elsewhere than in a browser.</p>
-    <p><code>&lt;i-slide src='<a href="https://www.w3.org/Talks/Tools/b6plus/?full#3">https://www.w3.org/Talks/Tools/b6plus/?full#3</a>'&gt;&lt;/i-slide&gt;</code></p>
-    <p>allows to embed the third slide of the referenced slideset:</p>
-    <p><i-slide width="500" src='https://www.w3.org/Talks/Tools/b6plus/?full#3'></i-slide></p>
-
   </body>
 </html>

--- a/test/resources/demo.html
+++ b/test/resources/demo.html
@@ -10,19 +10,27 @@
 
     <p><code>&lt;i-slide&gt;</code> is a Web component that allows embedding HTML and PDF slides inside a Web page.</p>
 
+    <p>To use it, wrap <code>&lt;span is=i-slide&gt;...&lt;/span&gt;</code> around a link to a slide.</p>
+
     <p>It works with the <a href="https://shwr.me/">Shower HTML slides</a> engine.</p>
-    <pre><code>&lt;i-slide src='<a href="http://shower.github.io/shower/">http://shower.github.io/shower/</a>#2'&gt;&lt;/i-slide&gt;</code></pre>
+    <p><code>&lt;span is=i-slide&gt;&lt;a href='<a href="http://shower.github.io/shower/?full#2">http://shower.github.io/shower/?full#2</a>'&gt;Shower slide 2&lt;/a&gt;&lt;/span&gt;</code></p>
     <p>allows to embed the second slide of the referenced slideset:</p>
-    <p><i-slide src='https://shower.github.io/shower/#2' width="500"></i-slide></p>
+    <p><span is=i-slide width="500"><a href='https://shower.github.io/shower/?full#2'>Shower slide 2</a></span></p>
 
     <p>It also works with the <a href="https://www.w3.org/Talks/Tools/b6plus/">b6+ HTML slides</a> engine.</p>
-    <pre><code>&lt;i-slide src='https://www.w3.org/Talks/Tools/b6plus/#3'&gt;&lt;/i-slide&gt;</code></pre>
+    <p><code>&lt;span is=i-slide&gt;&lt;a href='<a href="https://www.w3.org/Talks/Tools/b6plus/?full#3">https://www.w3.org/Talks/Tools/b6plus/?full#3</a>'&gt;B6+ slide 3&lt;/a&gt;&lt;/span&gt;</code></p>
     <p>allows to embed the third slide of the referenced slideset:</p>
-    <p><i-slide src='https://www.w3.org/Talks/Tools/b6plus/#3' width="500"></i-slide></p>
+    <p><span is=i-slide width="500"><a href='https://www.w3.org/Talks/Tools/b6plus/?full#3'>B6+ slide 3</a></span></p>
 
     <p>It also works with the PDF slides.</p>
-    <pre><code>&lt;i-slide src='<a href="https://www.w3.org/2020/Talks/mlws/ba-media.pdf">https://www.w3.org/2020/Talks/mlws/ba-media.pdf</a>#page=5'&gt;&lt;/i-slide&gt;</code></pre>
+    <p><code>&lt;span is=i-slide&gt;&lt;a href='<a href="https://www.w3.org/2020/Talks/mlws/ba-media.pdf#page=5">https://www.w3.org/2020/Talks/mlws/ba-media.pdf#page=5</a>'&gt;PDF slide 5&lt;/a&gt;&lt;/span&gt;</code></p>
     <p>allows to embed the fifth slide of the referenced slideset:</p>
-    <p><i-slide src='https://www.w3.org/2020/Talks/mlws/ba-media.pdf#page=5' width="500"></i-slide></p>
+    <p><span is=i-slide width="500"><a href='https://www.w3.org/2020/Talks/mlws/ba-media.pdf#page=5'>PDF slide 5</a></span></p>
+
+    <p>It is also possble to use <code>&lt;i-slide&gt;</code> as a tag. But note that this means there will be no link to the slide if JavaScript is turned off or it the page is used elsewhere than in a browser.</p>
+    <p><code>&lt;i-slide src='<a href="https://www.w3.org/Talks/Tools/b6plus/?full#3">https://www.w3.org/Talks/Tools/b6plus/?full#3</a>'&gt;&lt;/i-slide&gt;</code></p>
+    <p>allows to embed the third slide of the referenced slideset:</p>
+    <p><i-slide width="500" src='https://www.w3.org/Talks/Tools/b6plus/?full#3'></i-slide></p>
+
   </body>
 </html>


### PR DESCRIPTION
This is an exploration inspired by [issue #35, ‘Add new "replace" mode’](https://github.com/w3c/i-slide/issues/35) and by [my comment on integrating i-slide into scribe.perl](https://github.com/w3c/scribe2/pull/10#issuecomment-942205731).

This patch makes i-slide a ‘customized built-in element’ instead of an ‘autonomous custom element’. In particular, i-slide becomes a subclass of the ‘span’ element.

The idea is to make a normal link to a slide, e.g., `<a href="myslides#x3">slide 3</a>`, and then wrap that in a specialized ‘span’ element: `<span is=i-slide>...</span>`. This provides good fallback for non-browser applications (and for browsers when JavaScript is unavailable).

Putting the ‘is’ attribute on the ‘a’ element itself would have been shorter, but it unfortunately does not work. I-slide needs to attach a ‘shadow root’ and only a handful of HTML elements allow that. In fact, the only inline element that can have a shadow root is ‘span’.

Current Safari does not support customized built-in elements. (It only supports autonomous custom elements.) If necessary, there are polyfills, though.

Note that this patch still has a to-do item: The slide is initialized from the ‘href’ attribute when the i-slide is created, but if some other script in the document changes the ‘href’ later, the slide is not updated.