### PR TITLE
Always take width/height imposed by CSS into account

### DIFF
--- a/ISlide.js
+++ b/ISlide.js
@@ -499,12 +499,12 @@ class ISlide extends HTMLElement {
     const cacheEntry = cache[docUrl];
 
     // Initial width is explicitly set
-    const width = this.#width;
+    const width = this.clientWidth || this.#width;
 
     // Initial height may be explicitly set. If not, we'll set it from the
     // width based on the default aspect ratio, unless the slide ratio is
     // already known.
-    let height = this.#height ||
+    let height = this.clientHeight || this.#height ||
       (cacheEntry.width && cacheEntry.height ?
         cacheEntry.height * width / cacheEntry.width :
         width / defaultAspectRatio);
@@ -755,10 +755,10 @@ class ISlide extends HTMLElement {
 
     // Compute the dimensions of the i-slide element in the absence of
     // additional constraints, and set box dimensions that are not yet imposed.
-    const targetWidth = this.#width;
+    const targetWidth = this.clientWidth || this.#width;
     box.width = box.width || this.#pendingWidth || targetWidth;
 
-    const targetHeight = this.#height ||
+    const targetHeight = this.clientHeight || this.#height ||
       (this.#intrinsicWidth && this.#intrinsicHeight ?
         this.#intrinsicHeight * box.width / this.#intrinsicWidth :
         box.width / defaultAspectRatio);

--- a/test/i-slide.js
+++ b/test/i-slide.js
@@ -102,10 +102,10 @@ const tests = {
       ]
     },
     {
-      slide: { url: "shower.html#2", width: 500 },
+      slide: { url: "shower.html#2", width: 600 },
       expects: [
         { path: "ol", result: true },
-        { path: ".width", result: 500 }
+        { path: ".width", result: 600 }
       ]
     },
     {
@@ -417,6 +417,30 @@ const tests = {
         return promise;
       },
       result: `width:${144*(16/9)}px height:144px`
+    }
+  },
+
+  "scales content when box height is imposed in CSS (HTML slide)": {
+    slide: { url: "shower.html#1", css: `i-slide { display: block; width: 800px; height: ${800/(16/9)}px; }` },
+    expects: {
+      eval: async _ => {
+        const rootEl = window.slideEl.shadowRoot.querySelector("html");
+        const styles = window.getComputedStyle(rootEl);
+        return `width:${styles.width} height:${styles.height}`;
+      },
+      result: `width:800px height:${800/(16/9)}px`
+    }
+  },
+
+  "scales content when box height is imposed in CSS (PDF slide)": {
+    slide: { url: "slides.pdf#1", css: `i-slide { display: block; width: 800px; height: ${800/(16/9)}px; }` },
+    expects: {
+      eval: async _ => {
+        const rootEl = window.slideEl.shadowRoot.querySelector("canvas");
+        const styles = window.getComputedStyle(rootEl);
+        return `width:${styles.width} height:${styles.height}`;
+      },
+      result: `width:800px height:${800/(16/9)}px`
     }
   },
 


### PR DESCRIPTION
This update makes the code take `clientWidth` and `clientHeight` into account when rendering the slide for the first time, to handle the situation where the resize event gets triggered before rendering (which happens when the ISlide element is rendered as a block with explicit `width` and `height` CSS properties).

A non-regression test was added to the test suite.

The width of one of the tests was adjusted to avoid off-by-1 fluctuating errors, which seem to be triggered by some rounding issue when content gets rendered (not a real code error in the sense that the content eventually takes the right dimensions, although there may be something to improve to avoid re-scaling the content).

Fix issue #42