### PR TITLE
Add ability to load slides from data URL

### DIFF
--- a/ISlide.js
+++ b/ISlide.js
@@ -387,7 +387,6 @@ class ISlide extends HTMLElement {
       if (!el?.href) {
 	return;
       }
-      console.log(cacheKey, cache[cacheKey]);
 
       // Inspired from https://stackoverflow.com/posts/12094943/revisions
       const base64Marker = "application/pdf;base64,";

--- a/ISlide.js
+++ b/ISlide.js
@@ -139,6 +139,7 @@ class ISlide extends HTMLElement {
       const el = document.getElementById(id);
       if (el?.href) {
 	this.#srcref = value;
+	this.#loadPDFScripts();
       } else {
 	value = '';
       }

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ This repository hosts a Web component that may be used to inline individual HTML
     <p>PDF slides work too:</p>
     <p><i-slide src="https://example.org/myslides.pdf#page=1"></i-slide></p>
 
+    <p>PDF slides loaded via a data: URL work as well:</p>
+    <p><a href="data:application/pdf;base64,..." id="datapdf">download slides</a><i-slide srcref="datapdf#page=1"></i-slide></p>
+
+
     <p>Fallback content can be specified:</p>
     <p><i-slide src="https://example.org/notfound#4">[Slide 4 of my slide set]</i-slide></p>
 
@@ -48,7 +52,7 @@ customElements.define('my-slide', ISlide);
 
 `i-slide.js` automatically registers the ISlide component and associates it with the `i-slide` tagname; you do not need any additional script to start making use of `i-slide`elements.
 
-The `i-slide.js` module can also be imported with a query string to automatically replace elements matching a selector set in a `selector` parameter with `i-slide` elements - in that case, the `src` attribute of the `i-slide` element will be copied from either an `href`, `src` or `data-islide-src` attribute present in the original element. This mode allows to use i-slide on regular markup. For instance:
+The `i-slide.js` module can also be imported with a query string to automatically replace elements matching a selector set in a `selector` parameter with `i-slide` elements - in that case, the `src` attribute of the `i-slide` element will be copied from either an `href`, `src` or `data-islide-src` attribute present in the original element; and the `srcref` attribute from a matching `data-islide-srcref` attribute. This mode allows to use i-slide on regular markup. For instance:
 ```html
 <script src="i-slide.js?selector=a.islide" type="module"></script>
 <body>
@@ -64,7 +68,7 @@ The Web element supports:
 
 - HTML slides made with the [Shower Presentation Engine](https://shwr.me/)
 - HTML slides made with the [b6+ slide framework](https://www.w3.org/Talks/Tools/b6plus/)
-- PDF slides
+- PDF slides (either external or loaded via a `data:` URL)
 
 #### Targeting individual slides
 

--- a/i-slide.js
+++ b/i-slide.js
@@ -7,10 +7,11 @@ if (params.get("selector")) {
   document.querySelectorAll(params.get("selector")).forEach(
     el => {
       const newEl = document.createElement("i-slide");
-      const src = el.getAttribute("href") || el.getAttribute("src") || el.dataset["islidesrc"];
+      const src = el.getAttribute("href") || el.getAttribute("src") || el.dataset["islideSrc"];
       newEl.setAttribute("src", src);
-      if (el.dataset["islidesrcref"]) {
-	newEl.setAttribute("srcref", el.dataset["islidesrcref"]);
+      const srcref = el.dataset["srcref"] || el.dataset["islideSrcref"];
+      if (srcref) {
+        newEl.setAttribute("srcref", srcref);
       }
       el.replaceWith(newEl);
     });

--- a/i-slide.js
+++ b/i-slide.js
@@ -7,8 +7,11 @@ if (params.get("selector")) {
   document.querySelectorAll(params.get("selector")).forEach(
     el => {
       const newEl = document.createElement("i-slide");
-      const src = el.getAttribute("href") || el.getAttribute("src") || el.dataset["islideSrc"];
+      const src = el.getAttribute("href") || el.getAttribute("src") || el.dataset["islidesrc"];
       newEl.setAttribute("src", src);
+      if (el.dataset["islidesrcref"]) {
+	newEl.setAttribute("srcref", el.dataset["islidesrcref"]);
+      }
       el.replaceWith(newEl);
     });
 }


### PR DESCRIPTION
This adds a new srcref attribute to i-slide which takes the id of a link element whose href attribute contains a data: URL that base64-encodes a PDF file. Individual slide are indicated with a fragment added to that id