### PR TITLE
Override slide numbering styles to render the correct slide number

### DIFF
--- a/ISlide.js
+++ b/ISlide.js
@@ -626,7 +626,10 @@ class ISlide extends HTMLElement {
         const origSlideEl = doc.getElementById(slideId) ||
               doc.querySelectorAll('.slide')[slideNumber - 1];
         if (!origSlideEl) throw new Error(`Could not find slide ${slideId} in ${docUrl}`);
-        const slideEl = origSlideEl.cloneNode(true) ;
+        this.#slideNumber = isNaN(slideNumber) ?
+          [...doc.querySelectorAll('.slide')].findIndex(s => s === origSlideEl) + 1 :
+          slideNumber;
+        const slideEl = origSlideEl.cloneNode(true);
         slideEl.style.marginLeft = '0';
         bodyEl.style.top = 'inherit';
         bodyEl.style.left = 'inherit';
@@ -661,6 +664,19 @@ class ISlide extends HTMLElement {
         this.#slideEl.style.overflow = 'hidden';
         this.#slideEl.style.height = `${height}px`;
         headEl.appendChild(this.#hostStyleEl);
+
+        // HTML slides are numbered through CSS, in an `.slide::after` rule
+        // that set the `content` property to `counter(slide)`. We only render
+        // one slide, let's force the value to the actual slide number
+        if (this.#slideNumber > 0) {
+          const slideNumberingStyle = document.createElement('style');
+          slideNumberingStyle.textContent = `
+            .slide::after {
+              content: "${this.#slideNumber}"
+            }
+          `;
+          headEl.appendChild(slideNumberingStyle);
+        }
 
         if (!cacheEntry.width) {
           // Nothing known about intrinsic slide dimensions for now,

--- a/test/i-slide.js
+++ b/test/i-slide.js
@@ -531,6 +531,50 @@ const tests = {
       },
       result: `width:${144*(16/9)}px height:144px`
     }
+  },
+
+  "shows the right slide number (b6+)": {
+    slide: "https://www.w3.org/Talks/Tools/b6plus/#3",
+    expects: {
+      eval: _ => {
+        const innerSlideEl = window.slideEl.shadowRoot.querySelector(".slide");
+        return window.getComputedStyle(innerSlideEl, ':after').content;
+      },
+      result: '"3"'
+    }
+  },
+
+  "shows the right slide number when an ID is specified (b6+) ": {
+    slide: "https://www.w3.org/Talks/Tools/b6plus/#media",
+    expects: {
+      eval: _ => {
+        const innerSlideEl = window.slideEl.shadowRoot.querySelector(".slide");
+        return window.getComputedStyle(innerSlideEl, ':after').content;
+      },
+      result: '"6"'
+    }
+  },
+
+  "shows the right slide number (shower)": {
+    slide: "shower.html#3",
+    expects: {
+      eval: _ => {
+        const innerSlideEl = window.slideEl.shadowRoot.querySelector(".slide");
+        return window.getComputedStyle(innerSlideEl, ':after').content;
+      },
+      result: '"3"'
+    }
+  },
+
+  "shows the right slide number when an ID is specified (shower) ": {
+    slide: "shower.html#plaintext",
+    expects: {
+      eval: _ => {
+        const innerSlideEl = window.slideEl.shadowRoot.querySelector(".slide");
+        return window.getComputedStyle(innerSlideEl, ':after').content;
+      },
+      result: '"3"'
+    }
   }
 };
 

--- a/test/resources/shower.html
+++ b/test/resources/shower.html
@@ -50,7 +50,7 @@
         <p class="note">Shower ['ʃəuə] noun. A person or thing that shows.</p>
     </section>
 
-    <section class="slide">
+    <section class="slide" id="plaintext">
         <h2>Plain text on your slides</h2>
         <p>Lorem ipsum dolor sit amet, consectetur <a href="#4">adipisicing</a> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, <em>quis nostrud</em> exercitation ullamco laboris <strong>nisi ut aliquip</strong> ex ea commodo consequat. Duis aute irure <i>dolor</i> in reprehenderit in voluptate velit esse cillum <b>dolore</b> eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in <code>&lt;culpa&gt;</code> qui officia deserunt mollit anim id est laborum.</p>
     </section>


### PR DESCRIPTION
Whenever the ISlide component needs to render a slide, it creates a fake slideset that only contains a copy of the slide to render. This is done on purpose to avoid having to clone the whole slideset whenever a slide is rendered (the main use case for the component is a page where all slides are rendered, the slideset would have to be cloned for each of the slide).

This works well for PDF slidesets, but HTML slidesets typically use a CSS rule of the form `.slide::after { content: counter(slide) }` to render the slide number. That works well when all slides are available, but means that the slide number ends up being "1" for all HTML slides rendered through the ISlide component.

The right solution would be to clone the whole slideset each time, as proposed in #49. But that's precisely what we're trying to avoid...

This update takes a different approach and rather inject a new CSS rule with the actual slide number. For example, `.slide::after { content: "4" }`.

By definition, this solution is more brittle because it relies on inner knowledge of how slide frameworks work. Shower and b6+ follow the same pattern today, but that could change in the future. Other HTML slide frameworks may use a different one. Also, the solution only accounts for slide numbers, while frameworks may have additional features that depend on the presence of all slides.