### PR TITLE
Improve logic that sets the slide number

### DIFF
--- a/ISlide.js
+++ b/ISlide.js
@@ -623,11 +623,12 @@ class ISlide extends HTMLElement {
         const headEl = doc.querySelector('head').cloneNode(true);
         const bodyEl = doc.querySelector('body').cloneNode();
         const slideNumber = parseInt(slideId, 10);
+        const origSlides = [...doc.querySelectorAll('.slide')];
         const origSlideEl = doc.getElementById(slideId) ||
-              doc.querySelectorAll('.slide')[slideNumber - 1];
+              origSlides[slideNumber - 1];
         if (!origSlideEl) throw new Error(`Could not find slide ${slideId} in ${docUrl}`);
         this.#slideNumber = isNaN(slideNumber) ?
-          [...doc.querySelectorAll('.slide')].findIndex(s => s === origSlideEl) + 1 :
+          origSlides.findIndex(s => s === origSlideEl) + 1 :
           slideNumber;
         const slideEl = origSlideEl.cloneNode(true);
         slideEl.style.marginLeft = '0';
@@ -635,6 +636,13 @@ class ISlide extends HTMLElement {
         bodyEl.style.left = 'inherit';
         bodyEl.style.margin = 'inherit';
         bodyEl.style.transformOrigin = '0 0';
+
+        // HTML slides are typically numbered through CSS, using a `slide`
+        // counter. We only render one slide, let's force the value to the
+        // actual slide number.
+        const totalSlides = origSlides.length;
+        slideEl.style.counterReset =
+          `slide ${this.#slideNumber - 1} numslides ${totalSlides}`;
 
         //  Works for Shower and b6
         slideEl.classList.add('active');
@@ -664,19 +672,6 @@ class ISlide extends HTMLElement {
         this.#slideEl.style.overflow = 'hidden';
         this.#slideEl.style.height = `${height}px`;
         headEl.appendChild(this.#hostStyleEl);
-
-        // HTML slides are numbered through CSS, in an `.slide::after` rule
-        // that set the `content` property to `counter(slide)`. We only render
-        // one slide, let's force the value to the actual slide number
-        if (this.#slideNumber > 0) {
-          const slideNumberingStyle = document.createElement('style');
-          slideNumberingStyle.textContent = `
-            .slide::after {
-              content: "${this.#slideNumber}"
-            }
-          `;
-          headEl.appendChild(slideNumberingStyle);
-        }
 
         if (!cacheEntry.width) {
           // Nothing known about intrinsic slide dimensions for now,

--- a/test/i-slide.js
+++ b/test/i-slide.js
@@ -538,9 +538,12 @@ const tests = {
     expects: {
       eval: _ => {
         const innerSlideEl = window.slideEl.shadowRoot.querySelector(".slide");
-        return window.getComputedStyle(innerSlideEl, ':after').content;
+        return "counter-reset: " +
+          window.getComputedStyle(innerSlideEl)["counter-reset"] +
+          "; content: " +
+          window.getComputedStyle(innerSlideEl, ":after").content;
       },
-      result: '"3"'
+      result: "counter-reset: slide 2 numslides 39; content: counter(slide)"
     }
   },
 
@@ -549,9 +552,12 @@ const tests = {
     expects: {
       eval: _ => {
         const innerSlideEl = window.slideEl.shadowRoot.querySelector(".slide");
-        return window.getComputedStyle(innerSlideEl, ':after').content;
+        return "counter-reset: " +
+          window.getComputedStyle(innerSlideEl)["counter-reset"] +
+          "; content: " +
+          window.getComputedStyle(innerSlideEl, ":after").content;
       },
-      result: '"6"'
+      result: "counter-reset: slide 5 numslides 39; content: counter(slide)"
     }
   },
 
@@ -560,9 +566,12 @@ const tests = {
     expects: {
       eval: _ => {
         const innerSlideEl = window.slideEl.shadowRoot.querySelector(".slide");
-        return window.getComputedStyle(innerSlideEl, ':after').content;
+        return "counter-reset: " +
+          window.getComputedStyle(innerSlideEl)["counter-reset"] +
+          "; content: " +
+          window.getComputedStyle(innerSlideEl, ":after").content;
       },
-      result: '"3"'
+      result: "counter-reset: slide 2 numslides 4; content: counter(slide)"
     }
   },
 
@@ -571,9 +580,12 @@ const tests = {
     expects: {
       eval: _ => {
         const innerSlideEl = window.slideEl.shadowRoot.querySelector(".slide");
-        return window.getComputedStyle(innerSlideEl, ':after').content;
+        return "counter-reset: " +
+          window.getComputedStyle(innerSlideEl)["counter-reset"] +
+          "; content: " +
+          window.getComputedStyle(innerSlideEl, ":after").content;
       },
-      result: '"3"'
+      result: "counter-reset: slide 2 numslides 4; content: counter(slide)"
     }
   }
 };


### PR DESCRIPTION
This implements Bert's improved logic suggested in: https://github.com/w3c/i-slide/pull/49#issuecomment-2780708606

Good thing about it is that, while the tests themselves currently assume that the `content` CSS rule is `counter(slide)` by default, the logic should also work with slidesets where the author adds custom styles to set `content` to another value such as `Slide number counter(slide)` or `counter(slide)/counter(numslides)` (FWIW, for the latter to work, a `counter-increment: numslides 0` rule will also need to be added).

Note the tests do not directly check the actual value rendered on screen, as I don't see any way to access it from JavaScript code (or did I miss something in the CSS Object Model?)